### PR TITLE
feat: dynamic game scaling

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -1,0 +1,50 @@
+const ASPECT_RATIO = 16 / 9;
+
+const config = {
+    type: Phaser.AUTO,
+    parent: 'game-container',
+    width: window.innerWidth,
+    height: window.innerHeight,
+    scale: {
+        mode: Phaser.Scale.FIT,
+        autoCenter: Phaser.Scale.CENTER_BOTH
+    },
+    scene: {
+        preload: preload,
+        create: create,
+        update: update
+    }
+};
+
+const game = new Phaser.Game(config);
+
+// adjust initial size
+resize();
+
+function preload() {
+    // preload assets
+}
+
+function create() {
+    // setup game
+}
+
+function update() {
+    // game loop
+}
+
+function resize() {
+    let width = window.innerWidth;
+    let height = window.innerHeight;
+    const currentRatio = width / height;
+
+    if (currentRatio > ASPECT_RATIO) {
+        width = height * ASPECT_RATIO;
+    } else {
+        height = width / ASPECT_RATIO;
+    }
+
+    game.scale.resize(width, height);
+}
+
+window.addEventListener('resize', resize);

--- a/index.html
+++ b/index.html
@@ -335,7 +335,12 @@
         </div>
     </footer>
 
+    <!-- Phaser Game Container -->
+    <div id="game-container"></div>
+
     <!-- JavaScript -->
+    <script src="https://cdn.jsdelivr.net/npm/phaser@3.70.0/dist/phaser.min.js"></script>
+    <script src="assets/js/game.js"></script>
     <script src="assets/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- configure Phaser game to match window dimensions
- resize game on window changes while preserving 16:9 aspect ratio
- load Phaser and new game script in index.html

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890f864ada883239fa74813297542d1